### PR TITLE
Implement multi-threaded batch classification

### DIFF
--- a/law_classifier/cli.py
+++ b/law_classifier/cli.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import List, Optional
 
-from .core import batch, classify_file
+from .core import classify_file
+from .io_utils import find_files
 from .rules import RuleEngine
 
 
@@ -24,7 +27,23 @@ def cmd_classify(args: argparse.Namespace) -> None:
 
 def cmd_batch(args: argparse.Namespace) -> None:
     engine = get_engine()
-    results = batch(Path(args.folder), ["*.txt", "*.docx", "*.pdf"], engine)
+    files = find_files(Path(args.folder), ["*.txt", "*.docx", "*.pdf"])
+    results = []
+
+    def _worker(path: Path):
+        try:
+            return classify_file(engine, path)
+        except Exception as exc:  # pragma: no cover - logging
+            logging.error("Помилка обробки %s: %s", path, exc)
+            return None
+
+    with ThreadPoolExecutor(max_workers=args.workers) as exc:
+        futs = [exc.submit(_worker, f) for f in files]
+        for fut in as_completed(futs):
+            res = fut.result()
+            if res is not None:
+                results.append(res)
+
     rows = [r.dict(by_alias=True) for r in results]
     if args.out:
         import csv

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,3 +19,25 @@ def test_cli_classify(tmp_path):
         sys.stdout = sys_stdout
     out = buf.getvalue()
     assert "BUD" in out
+
+
+def test_cli_batch_multiworker(tmp_path):
+    f1 = tmp_path / "a.txt"
+    f1.write_text("Постанова про державний бюджет")
+    f2 = tmp_path / "b.txt"
+    f2.write_text("Науковець отримав грант")
+
+    import json
+    import sys
+    from io import StringIO
+
+    buf = StringIO()
+    sys_stdout = sys.stdout
+    sys.stdout = buf
+    try:
+        main(["batch", str(tmp_path), "--workers", "2"])
+    finally:
+        sys.stdout = sys_stdout
+    data = json.loads(buf.getvalue())
+    categories = {d["категорія"] for d in data}
+    assert {"BUD", "SCI"} <= categories


### PR DESCRIPTION
## Summary
- parallelize CLI batch command using `ThreadPoolExecutor`
- log and skip files that raise parsing errors in workers
- add test to verify multi-worker batch execution

## Testing
- `black law_classifier/cli.py tests/test_cli.py`
- `isort law_classifier/cli.py tests/test_cli.py`
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: 'docx', 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68501f21b14c832b9c500fb388160467