### PR TITLE
Add coverage-driven tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,81 @@
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+def _simple_yaml_load(text: str):
+    data = {}
+    current = None
+    for line in text.splitlines():
+        if line.endswith(":"):
+            current = line[:-1]
+            data[current] = []
+        elif line.strip().startswith("-") and current is not None:
+            val = line.split("-", 1)[1].strip().strip('"')
+            val = val.replace('\\\\', '\\')
+            data[current].append(val)
+    return data
+
+
+@pytest.fixture(autouse=True)
+def stub_optional_modules(monkeypatch):
+    # stub yaml
+    yaml_mod = types.ModuleType("yaml")
+    yaml_mod.safe_load = _simple_yaml_load
+    sys.modules["yaml"] = yaml_mod
+
+    # stub docx
+    docx_mod = types.ModuleType("docx")
+
+    class Document:
+        def __init__(self, path):
+            text = Path(path).read_text(encoding="utf-8")
+            self.paragraphs = [types.SimpleNamespace(text=text)]
+
+    docx_mod.Document = Document
+    sys.modules["docx"] = docx_mod
+
+    # stub pdfminer.high_level
+    pdfminer_high = types.ModuleType("pdfminer.high_level")
+
+    def extract_text(path: str):
+        return Path(path).read_text(encoding="utf-8")
+
+    pdfminer_high.extract_text = extract_text
+    sys.modules["pdfminer.high_level"] = pdfminer_high
+    pdfminer_mod = types.ModuleType("pdfminer")
+    pdfminer_mod.high_level = pdfminer_high
+    sys.modules["pdfminer"] = pdfminer_mod
+
+    root = Path(__file__).resolve().parents[1]
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
+
+    # stub pydantic BaseModel and Field for schema module
+    pydantic_mod = types.ModuleType("pydantic")
+
+    class _Base:
+        def __init__(self, **kwargs):
+            for k, v in kwargs.items():
+                setattr(self, k, v)
+
+        def dict(self, *args, **kwargs):
+            return self.__dict__
+
+        def json(self, *args, **kwargs):
+            import json
+            return json.dumps(self.__dict__, ensure_ascii=False, default=str)
+
+    def Field(*args, **kwargs):
+        return None
+
+    pydantic_mod.BaseModel = _Base
+    pydantic_mod.Field = Field
+    sys.modules["pydantic"] = pydantic_mod
+
+    yield
+
+    for name in ["yaml", "docx", "pdfminer", "pdfminer.high_level", "pydantic"]:
+        sys.modules.pop(name, None)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,8 @@
 from pathlib import Path
 
-from law_classifier.cli import main
-
-
 def test_cli_classify(tmp_path):
+    from law_classifier.cli import main
+
     file = tmp_path / "test.txt"
     file.write_text("Постанова про державний бюджет")
     # capture output

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+import csv
+
+
+def test_batch_and_save_csv(tmp_path):
+    from law_classifier.core import batch, save_csv
+    from law_classifier.rules import RuleEngine
+
+    engine = RuleEngine(Path("data/terms.yaml"))
+    f1 = tmp_path / "a.txt"
+    f1.write_text("Постанова про державний бюджет")
+    f2 = tmp_path / "b.txt"
+    f2.write_text("Простий текст")
+
+    results = batch(tmp_path, ["*.txt"], engine)
+    assert len(results) == 2
+    cats = {getattr(r, "категорія", None) for r in results}
+    assert {"BUD", "UNLABELLED"} <= cats
+
+    csv_path = tmp_path / "res.csv"
+    save_csv(results, csv_path)
+    with open(csv_path, newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+    assert len(rows) == 2
+    assert {row["категорія"] for row in rows} == cats

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+import pytest
+
+
+def test_read_file_missing_docx(monkeypatch, tmp_path):
+    from law_classifier import io_utils
+
+    doc = tmp_path / "file.docx"
+    doc.write_text("text")
+    monkeypatch.setattr(io_utils, "Document", lambda path: (_ for _ in ()).throw(ImportError("no docx")))
+    with pytest.raises(io_utils.ParseError):
+        io_utils.read_file(doc)
+
+
+def test_read_file_missing_pdf(monkeypatch, tmp_path):
+    from law_classifier import io_utils
+
+    pdf = tmp_path / "file.pdf"
+    pdf.write_text("text")
+    monkeypatch.setattr(io_utils, "extract_text", lambda path: (_ for _ in ()).throw(ImportError("no pdf")))
+    with pytest.raises(io_utils.ParseError):
+        io_utils.read_file(pdf)

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1,9 +1,8 @@
 from pathlib import Path
 
-from law_classifier.rules import RuleEngine
-
-
 def test_budget_category():
+    from law_classifier.rules import RuleEngine
+
     engine = RuleEngine(Path("data/terms.yaml"))
     text = "Державний бюджет наукових досліджень"
     code, terms = engine.match(text)
@@ -12,6 +11,8 @@ def test_budget_category():
 
 
 def test_unlabelled():
+    from law_classifier.rules import RuleEngine
+
     engine = RuleEngine(Path("data/terms.yaml"))
     text = "Це простий текст без згадок"
     code, terms = engine.match(text)


### PR DESCRIPTION
## Summary
- create pytest fixture to stub optional dependencies
- adjust existing tests to import lazily
- test batch and CSV saving
- test error handling when optional libs are missing

## Testing
- `pytest -q`
- `pytest --cov=law_classifier -q` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68501f26709c832bb0bd2efea47e7bd4